### PR TITLE
Change default directory to /var/run

### DIFF
--- a/lib/pidfile.rb
+++ b/lib/pidfile.rb
@@ -7,7 +7,7 @@ class PidFile
 
   DEFAULT_OPTIONS = {
     :pidfile => File.basename($0, File.extname($0)) + ".pid",
-    :piddir => '/tmp',
+    :piddir => '/var/run',
   }
 
   def initialize(*args)


### PR DESCRIPTION
On many Linux distributions, /tmp is not meant to be used for long-lived files and will be cleaned up after a certain period. /var/run is the appropriate place for pidfiles.
